### PR TITLE
Revisions for the Export Your Notebook section 

### DIFF
--- a/exporting_the_notebook.md
+++ b/exporting_the_notebook.md
@@ -1,21 +1,21 @@
 ---
 title: Exporting the Jupyter Notebook
-minutes: 30
+teaching: 15
+exercises: 15
+objectives:
+- Recognize and identify the various publishing related data formats.
+- Use NBConvert to export your notebooks in a variety of formats, including HTML, PDF, LaTeX, and Markdown.
+- Select an appropriate output format for your publication and justify your choice.
+keypoints:
+- Jupyter Notebooks can be converted to a number of formats relevant for scholarly communication and publishing, including HTML, PDF, and Markdown.
+- Some code repositories, including GitHub, "know" how to render Jupyter Notebook format natively, and hence can be used for publishing notebooks for public viewing.
 ---
 
 # Introduction
 
-At the end of this lesson, you will be able to
+The native Jupyter Notebook format is not (yet?) among those accepted by scholarly publishers. Nor do web browsers know how to render it. Hence, when it comes time to publish your Notebooks, whether as part of a scholarly publication or simply to the web, it needs to be exported to a suitable output format. This is what the `jupyter nbocnvert` command does.
 
-- Describe the advantages of common electronic publication formats
-- Convert your existing Jupyter Notebooks into common publication formats
-
-# Learning Objectives
-
-- Recognize and identify the various publishing related data formats.
-- Use NBConvert to export their notebooks in a variety of formats including HTML, PDF, markdown, LaTeX and Reveal.js slides.
-- Select an appropriate output format for their publication and justify their choice.
-- Create a GitHub account and upload a Jupyter notebook to your GitHub repository for public viewing. 
+In this lesson, we will look at several formats relevant to scholarly publishing and publishing to the web, and we will learn how to export a notebook to such formats.
 
 # Output formats
 

--- a/exporting_the_notebook.md
+++ b/exporting_the_notebook.md
@@ -19,35 +19,30 @@ In this lesson, we will look at several formats relevant to scholarly publishing
 
 # Output formats
 
-There are several outlets for our research and each of them often have specific requirements for the formats they can use.
-Also, traditionally, publications have been distributed in print journals on a letter-size page, as more journals publish online, electronic formats are becoming popular.
-How do you determine the best publication formats to output your publications in?
-Is it possible to create multiple outputs for your work for multiple publication venues?
+Scholarly publishers typically accept one or several Word-processing oriented formats, which are often binary or at least not meant for human consumption. For sharing or publishing data and analysis documentation, a text format that is easy to read and doesn't require special-purpose software is usually best. How do you determine the best format(s) to export your Notebook to?
 
-Below, we briefly describe a few formats that are widely used for publication.
+Below we briefly describe a few formats that are widely used in scholarly communication.
 
 ## PDF
 
-The PDF format is primarily used for paper-based output.  It contains information about the paper size and the margins.  It can be displayed on a webpage but it is somewhat like posting an image.
+The PDF format is primarily used for paper-based output.  It contains information about the paper size and the margins.  Most web browsers know how to display it, but posting it to the web is somewhat like posting an raster-graphics image - it is not meant to be built upon or modified.
 
-You would use the PDF format if you were interested in printing a copy of your notebook for hand-written comments or for sending to co-authors for reading and commenting in tools like Adobe Acrobat.
+You would use the PDF format if you were interested in printing a copy of your notebook (for filing a paper copy, or hand-writing comments), or for sending to co-authors for reading and commenting (which will likely require tools such as Adobe Acrobat).
 
 ## HTML
 
-The HTML format is the native format for the internet.  It does not contain information about printing on paper usually.  Exporting to this format is a popular means of posting content to the web.
+HTML is the native format for the web.  It does not usually contain information about printing on paper.  Exporting to this format is a popular means of posting content to the web so that browsers can render it in the best way suitable for the device they are running on. (HTML is also a format rich in metadata and context information for search engines.)
 
 If you have a website that you manage, publishing to HTML can make it easy to add your notebook as a page to a website.
 
 ## Markdown
 
-Markdown is a plain-text format that was designed to be easily exported to HTML.  It has the advantage over HTML as having fewer characters used for markup which makes it more human-readable.
+Markdown is a plain-text format that was designed to both be human-readable without any special-purpose rendering tools, and to be easily exported to HTML.
 
 ## LaTeX
 
-LaTeX is a plain-text format that is often compiled into a PDF format using the LaTeX software.  It was originally created for mathematical typesetting and is widely used for publication.
+LaTeX is a plain-text format designed for authoring documents that will subsequently be typeset. It is widely used in publishing, and often accepted as a manuscript submission format, especially in fields that routinely need extensive mathematical typesetting capabilities. For publishing, sharing, and reading LaTeX is often compiled into a PDF format.  Depending on your field, your co-authors may be more comfortable editing LaTeX files than Notebook files.
 
-Some of your co-authors may be more comfortable editing LaTeX files than notebook files.
-It is also often used as a submission format for journals.
 
 ## Reveal.js
 

--- a/exporting_the_notebook.md
+++ b/exporting_the_notebook.md
@@ -43,47 +43,62 @@ Markdown is a plain-text format that was designed to both be human-readable with
 
 LaTeX is a plain-text format designed for authoring documents that will subsequently be typeset. It is widely used in publishing, and often accepted as a manuscript submission format, especially in fields that routinely need extensive mathematical typesetting capabilities. For publishing, sharing, and reading LaTeX is often compiled into a PDF format.  Depending on your field, your co-authors may be more comfortable editing LaTeX files than Notebook files.
 
+# Exporting a Notebook
 
-## Reveal.js
+Notebooks can be exported through web-based user interface, or from the command line. The web-based interface in essence runs the same command as one would on the command line, and hence has the same installartion dependencies.
 
-# Discussion
+## Dependencies
 
-Students can discuss the formats of recent publications they have read or created recently.  We could also find examples in the literature of each format.  (PLOS, Nature)
+Exporting to LaTeX format will require [Pandoc](http://pandoc.org) to be installed. Exporting to PDF works through generating LaTeX first (and has those dependencies as well), and then needs a TeX installation to generate PDF.
 
-# Conversion of notebooks to other formats
+## From the command line
 
-One benefit of using an open format to write your research is that it is often possible to convert from the open format to other formats.
-The Jupyter Notebook allows for the conversion of the open notebook format to other formats such as PDF and HTML.
+The command is `jupyter nbconvert`, followed by notebook to convert, destination format (option `--to <format>`) and output filename (option `--output <filename>`):
 
-You can produce a converted file from the Jupyter Notebook graphical interface.
-In the File/Download As menu, there are options for
-
-## Demonstration
-
-Here we provide a short demo of downloading these formats
-
-- PDF
-- HTML
-- Markdown
-
-## Callout on PDF Export
-
-We are going to demonstrate the PDF export ability of the notebook.  To do this on your Jupyter installation will require the installation of the Pandoc and LaTeX libraries.
-
-## Callout on command-line NBConvert
-
-Also, you can perform the export functions at the command line if you want to include the conversion step in a reproducible workflow.
-
-```
-jupyter nbconvert example_jupyter_notebook.ipynb --to pdf --output output.pdf
-jupyter nbconvert example_jupyter_notebook.ipynb --to html --output output.html
-jupyter nbconvert example_jupyter_notebook.ipynb --to html --output output
+```sh
+$ jupyter nbconvert my_notebook.ipynb --to markdown --output output.md
 ```
 
-If you would like to learn more about the NBConvert tool, you can visit the
-[documentation](https://nbconvert.readthedocs.io/en/latest/).
+Or to HTML format:
 
-## Callout on images
+```sh
+$ jupyter nbconvert my_notebook.ipynb --to html --output output.html
+```
 
-If your Jupyter notebook has plot images generated from your code, they will be embedded in your HTML and PDF documents.  If however, you export to the Markdown format, they will be included in a folder in a zipped archive.
+The default HTML template (`full`) includes headers and everything needed to form a complete HTML document. If you wanted to embed the resulting HTML as a fragment into, say, [a blog post](http://nbviewer.jupyter.org/github/fperez/blog/blob/master/120907-Blogging%20with%20the%20IPython%20Notebook.ipynb), use the `basic` template:
+
+```sh
+$ jupyter nbconvert my_notebook.ipynb --to html --template basic --output output.html
+```
+
+[Full documentation of the NBConvert tool]((https://nbconvert.readthedocs.io/en/latest/) is available online.
+
+## From the web-based user interface
+
+In the _File->Download As_ menu, click the desired format. The conversion result will download to your computer.
+
+## Using `nbconvert` to execute or extract code
+
+The `jupyter nbconvert` command-line tool can be used to execute a notebook in whole and capture the result, by "converting" to the `notebook` format:
+
+```sh
+$ jupyter nbconvert --to notebook --execute my_notebook.ipynb
+```
+
+This generates `my_notebook.nbconvert.ipynb`, a new notebook that is the same as the source notebook but with all the output from code cells captured.
+
+You can also extract the code from a notebook into an executable script, i.e., for an iPython notebook extract the Python code cells into a Python script:
+
+```sh
+$ jupyter nbconvert --to script my_notebook.ipynb
+```
+
+## Exercises
+
+Use one or more of the notebooks you have created during this course.
+* Export notebook(s) to the following formats, using the web-interface and the command line: Markdown, HTML
+    * Observe which files get created in which arrangement.
+* If `pandoc` and LaTeX are installed, also convert to LaTeX and PDF. Alternatively, can use a [tmpnb](https://github.com/jupyter/tmpnb) instance.
+* Extract executable Python script from Notebook.
+* Execute notebook so that the result(s) of the code blocks is captured in a new notebook.
 

--- a/instructor_notes.md
+++ b/instructor_notes.md
@@ -22,12 +22,25 @@ Total: 2 hrs, 35 minutes
 
 ### Customization
 - If your participants are expecting to be able to create PDF images, you can instruct them to download and install the Pandoc and LaTeX packages in advance of the workshop.  However, these may produce installation troubles.
+    * Use [TeX Live](https://www.tug.org/texlive/quickinstall.html) for installing TeX/LaTeX.
+    * For those using `conda` already as their installer, the following command should [install Pandoc without issue from the conda-forge](https://anaconda.org/conda-forge/pandoc):
+        conda install -c conda-forge pandoc=1.19.2
+
+- If installation of TeXLive and Pandoc risk going beyond the scope of the workshop, consider using or hosting an instance of [tmpnb](https://github.com/jupyter/tmpnb), "the temporary notebook service".
+    * The institution hosting the workshop may already run such a service. It's worth enquiring with the campus IT group.
+
+- Time permitting, and depending on students' experience level with installing Python packages you may not currently have installed, you can also try "real" notebooks from publications or books, such as some of the following:
+    * [Notebooks from 'Python for Bioinformatics'](https://github.com/tiagoantao/bioinf-python/blob/master/notebooks/Welcome.ipynb). In particular, those under the section _Simulation in Population Genetics_ don't need to download datasets as the first step.
+    * Wang Z and Ma'ayan A. An open RNA-Seq data analysis pipeline tutorial with an example of reprocessing data from a recent Zika virus study [version 1; referees: 2 approved]. _F1000Research_ 2016, 5:1574 doi: [10.12688/f1000research.9110.1](http://dx.doi.org/10.12688/f1000research.9110.1) [Jupyter Notebook](https://github.com/maayanlab/Zika-RNAseq-Pipeline/blob/master/Zika.ipynb)
+
+- For execution, can use [the `-student` version of the Data Exploration lesson's notebook](https://github.com/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter/blob/master/Data_exploration_student.ipynb).
 
 ### Resources
-- We have included callouts for some of the more involved aspects of notebook conversion.
 - It is worth verifying before the lesson that your installation of the notebook gives the expected behavior with images.  The most portable thing is to embed the images in the document.
 - By default, GUI html export embeds as Base64
 - By default, GUI markdown export creates a folder and a zip
+
+- _Exporting the notebook:_ If your Jupyter notebook has plot images generated from your code, they will be embedded in your HTML and PDF documents.  If however, you export to the Markdown format, they will be included in a folder in a zipped archive.
 
 ## 2. Documentation  
 

--- a/instructor_notes.md
+++ b/instructor_notes.md
@@ -27,7 +27,8 @@ Total: 2 hrs, 35 minutes
         conda install -c conda-forge pandoc=1.19.2
 
 - If installation of TeXLive and Pandoc risk going beyond the scope of the workshop, consider using or hosting an instance of [tmpnb](https://github.com/jupyter/tmpnb), "the temporary notebook service".
-    * The institution hosting the workshop may already run such a service. It's worth enquiring with the campus IT group.
+    * To set this up, essentially all that's needed is Docker. This may be too much to ask of students (as it throws in another technology), but the institution hosting the workshop may already run a service for recruiting Linux VMs on the fly. The necessary machine need not have much resources - a 2GB/1CPU VM should completely suffice for our purposes, and we only need one such machine for the whole class.
+    * The default [Jupyter Notebook container used by tmpnb](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook) currently includes some but not enough of TeX needed by nbconvert. It also doesn't include `numpy` and other frequently used packages for scientific computing. See [here](https://github.com/Duke-GCB/jupyter-scipy-tmpnb-server) for how to create a custom container that includes all of that, and how to then supply that custom container to tmpnb as the one to spin up for every user.
 
 - Time permitting, and depending on students' experience level with installing Python packages you may not currently have installed, you can also try "real" notebooks from publications or books, such as some of the following:
     * [Notebooks from 'Python for Bioinformatics'](https://github.com/tiagoantao/bioinf-python/blob/master/notebooks/Welcome.ipynb). In particular, those under the section _Simulation in Population Genetics_ don't need to download datasets as the first step.


### PR DESCRIPTION
Focuses now on output formats that are available, and export as a capability in itself.

Should close #18 as obsolete.

I think this should also close #7.